### PR TITLE
Makes test case flexible

### DIFF
--- a/test_config.yaml
+++ b/test_config.yaml
@@ -11,8 +11,8 @@ fileExistenceTests:
   path: /usr/lib/presto/plugin/db2
   uid: 1000
   gid: 1000
-- name: presto-db2.jar
-  path: /usr/lib/presto/plugin/db2/presto-db2-347.jar
+- name: presto-db2-*.jar
+  path: /usr/lib/presto/plugin/db2/
 metadataTest:
   env:
   - key: JAVA_HOME


### PR DESCRIPTION
Test case should not be locked down to a specific presto or trino release.