### PR TITLE
Add graceful shutdown via sigterm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,5 +33,4 @@ USER presto:presto
 # Add Db2 connector
 COPY --from=builder --chown=presto:presto presto-db2-* /usr/lib/presto/plugin/db2
 
-RUN chmod +x ./run-presto.sh
-ENTRYPOINT ["./run-presto.sh"]
+CMD ["./run-presto.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,3 +32,6 @@ USER root
 USER presto:presto
 # Add Db2 connector
 COPY --from=builder --chown=presto:presto presto-db2-* /usr/lib/presto/plugin/db2
+
+RUN chmod +x ./run-presto.sh
+ENTRYPOINT ["./run-presto.sh"]

--- a/README.md
+++ b/README.md
@@ -40,3 +40,9 @@ Then:
 ```SHELL
 docker run -d -p 8080:8080 -v /foo/bar/db2.properties:/usr/lib/presto/default/etc/catalog/db2.properties:ro shawnzhu/prestodb:latest
 ```
+
+## Features
+
+### Graceful Shutdown
+
+Adds the [graceful shutdown](https://trino.io/docs/current/admin/graceful-shutdown.html) feature from Trino so that active queries have a grace period to finish before the worker node is shut down (like in a redeployment).

--- a/README.md
+++ b/README.md
@@ -45,4 +45,4 @@ docker run -d -p 8080:8080 -v /foo/bar/db2.properties:/usr/lib/presto/default/et
 
 ### Graceful Shutdown
 
-Adds the [graceful shutdown](https://trino.io/docs/current/admin/graceful-shutdown.html) feature from Trino so that active queries have a grace period to finish before the worker node is shut down (like in a redeployment).
+It adds the [graceful shutdown](https://trino.io/docs/current/admin/graceful-shutdown.html) feature from Trino such that on a SIGTERM signal to the container, the worker will have a grace period before interrupting active queries.

--- a/run-presto.sh
+++ b/run-presto.sh
@@ -1,14 +1,15 @@
 #!/bin/bash
 
-# set -xeuo pipefail
+set -xeuo pipefail
 
 graceful_shutdown() {
     echo "calling graceful shutdown"
-    curl -v -X PUT -d '"SHUTTING_DOWN"' -H "Content-type: application/json" http://localhost:8081/v1/info/state -H X-Presto-User:name
+    PORT=$(grep "^http-server.http.port=" /etc/presto/config.properties | cut -d '=' -f2)
+    curl -v -X PUT -d '"SHUTTING_DOWN"' -H "Content-type: application/json" http://localhost:$PORT\/v1/info/state -H X-Presto-User:name
 }
-trap graceful_shutdown SIGTERM
+trap graceful_shutdown TERM
 
-# set +e
+set +e
 grep -s -q 'node.id' /etc/presto/node.properties
 NODE_ID_EXISTS=$?
 set -e

--- a/run-presto.sh
+++ b/run-presto.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# set -xeuo pipefail
+
+graceful_shutdown() {
+    echo "calling graceful shutdown"
+    curl -v -X PUT -d '"SHUTTING_DOWN"' -H "Content-type: application/json" http://localhost:8081/v1/info/state -H X-Presto-User:name
+}
+trap graceful_shutdown SIGTERM
+
+# set +e
+grep -s -q 'node.id' /etc/presto/node.properties
+NODE_ID_EXISTS=$?
+set -e
+
+NODE_ID=""
+if [[ ${NODE_ID_EXISTS} != 0 ]] ; then
+    NODE_ID="-Dnode.id=${HOSTNAME}"
+fi
+
+exec /usr/lib/presto/bin/launcher run --etc-dir /etc/presto ${NODE_ID} "$@"
+

--- a/test_config.yaml
+++ b/test_config.yaml
@@ -19,4 +19,4 @@ metadataTest:
     value: /usr/lib/jvm/zulu11
   exposedPorts: ["8080"]
   cmd:
-  - /usr/lib/presto/bin/run-presto
+  - ./run-presto.sh


### PR DESCRIPTION
Closes #41.

Customizes the container [entrypoint](https://github.com/trinodb/trino/blob/master/core/docker/bin/run-trino) to initiate [graceful shutdown](https://trino.io/docs/current/admin/graceful-shutdown.html) for the Presto worker on a `SIGTERM` signal.