### PR TITLE
Revert "Update Trino to 396"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      TRINO_VERSION: 396
+      TRINO_VERSION: 390
 
     steps:
     - uses: actions/checkout@v2

--- a/test_config.yaml
+++ b/test_config.yaml
@@ -16,5 +16,5 @@ fileExistenceTests:
 metadataTest:
   envVars:
   - key: JAVA_HOME
-    value: /opt/java/openjdk
+    value: /usr/lib/jvm/zulu17
   exposedPorts: ["8080"]


### PR DESCRIPTION
Reverts IBM/docker-trino#54

Since we reverted the trino upgrade in Discuss, we should revert this change as well.

https://github.ibm.com/whitewater-analytics/discuss/pull/2877

Signed-off-by: Adrianna Beck [Adrianna.Beck@ibm.com](mailto:Adrianna.Beck@ibm.com)